### PR TITLE
Centralize config loading and bolster tooling

### DIFF
--- a/R/fetch_projections.R
+++ b/R/fetch_projections.R
@@ -11,7 +11,7 @@ suppressPackageStartupMessages({
 })
 
 # --- 1) SCRAPE the current week (leave season/week NULL to auto-detect current) ---
-# You can edit 'src' to sources you trust. The README documents weekly sources.  :contentReference[oaicite:1]{index=1}
+# You can edit 'src' to sources you trust. The README documents weekly sources.
 scr <- scrape_data(
   src = c("CBS","ESPN","FantasyPros","NumberFire","NFL","FFToday","FantasySharks","FleaFlicker","FantasyFootballNerd"),
   pos = c("QB","RB","WR","TE"),
@@ -20,7 +20,7 @@ scr <- scrape_data(
 )
 
 # --- 2) BUILD blended projections table (weighted average per FFA) ---
-proj <- projections_table(scr, avg_type = "weighted")  # average|robust|weighted  :contentReference[oaicite:2]{index=2}
+proj <- projections_table(scr, avg_type = "weighted")  # average|robust|weighted
 
 # proj now has standardized stat columns per position.
 # We'll map them to the column names your Python agent expects.

--- a/agent_cli.py
+++ b/agent_cli.py
@@ -1,11 +1,25 @@
-# agent_cli.py
-import os, sys
+"""Command line interface for the NFL prop agent.
+
+Loads projection data, runs the edge scanner, writes artifacts, and optionally
+posts Slack alerts.  Configuration is pulled from ``agent_config.yaml`` via
+``config.load_config`` to keep settings consistent with other entry points.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
 import pandas as pd
 
 from agent_core import scan_edges
 from alerts import alert_edges
+from config import load_config
+
 
 def load_projections(path: str) -> pd.DataFrame:
+    """Load projection CSV into a DataFrame, normalizing column names."""
     if not os.path.exists(path):
         alt = "data/raw_stats_current.csv"
         if os.path.exists(alt):
@@ -13,70 +27,20 @@ def load_projections(path: str) -> pd.DataFrame:
     if not os.path.exists(path):
         raise FileNotFoundError(f"Projections CSV not found at {path}.")
     df = pd.read_csv(path)
-    # Normalize core columns
     for c in ("player", "team", "pos"):
         if c not in df.columns:
-            for altc in [c.title(), c.upper(), "Position" if c=="pos" else c]:
+            for altc in [c.title(), c.upper(), "Position" if c == "pos" else c]:
                 if altc in df.columns:
                     df.rename(columns={altc: c}, inplace=True)
                     break
-    print(f"Loaded projections: {len(df):,} rows, {len(df.columns)} cols from {path}")
+    logging.info(
+        "Loaded projections: %s rows, %s cols from %s", len(df), len(df.columns), path
+    )
     return df
 
-def default_config():
-    target_books = [
-        "draftkings","fanduel","caesars","betmgm","pointsbetus","bet365",
-        "barstool","espnbet","betway"
-    ]
-    markets = {
-        "base": [
-            "player_pass_yds","player_rush_yds","player_reception_yds",
-            "player_receptions","player_pass_tds","player_rush_tds",
-            "player_reception_tds","player_interceptions",
-            "player_pass_completions","player_longest_reception","player_longest_rush"
-        ],
-        "heavy": [
-            "player_pass_yds","player_rush_yds","player_reception_yds",
-            "player_receptions","player_pass_tds","player_rush_tds",
-            "player_reception_tds","player_interceptions",
-            "player_pass_completions","player_pass_attempts",
-            "player_longest_reception","player_longest_rush"
-        ]
-    }
-    sigma_defaults = {
-        "QB": {
-            "player_pass_yds": 45.0, "player_pass_tds": 0.7, "player_interceptions": 0.5,
-            "player_pass_completions": 5.5, "player_pass_attempts": 6.5
-        },
-        "RB": {
-            "player_rush_yds": 26.0, "player_rush_tds": 0.5, "player_receptions": 1.1,
-            "player_reception_yds": 18.0, "player_longest_rush": 9.0
-        },
-        "WR": {
-            "player_receptions": 1.2, "player_reception_yds": 22.0, "player_reception_tds": 0.5,
-            "player_longest_reception": 10.0
-        },
-        "TE": {
-            "player_receptions": 1.0, "player_reception_yds": 18.0, "player_reception_tds": 0.45,
-            "player_longest_reception": 8.0
-        }
-    }
-    return {
-        "regions": "us,us2",
-        "target_books": target_books,
-        "markets": markets,
-        "sigma_defaults": sigma_defaults,
-        "blend_alpha": 0.35,
-        "bankroll": 2000.0,
-        "unit_pct": 0.01,
-        "stake_bands": [
-            {"min_ev": 0.08, "stake_u": 1.0},
-            {"min_ev": 0.05, "stake_u": 0.7},
-            {"min_ev": 0.03, "stake_u": 0.5},
-        ]
-    }
 
 def advice_lines(df: pd.DataFrame, threshold: float) -> str:
+    """Format human-readable advice lines for Slack/console."""
     if df is None or df.empty:
         return "No edges found."
     name_map = {
@@ -105,25 +69,29 @@ def advice_lines(df: pd.DataFrame, threshold: float) -> str:
         )
     return "\n".join(lines)
 
+
 def main() -> int:
+    """Run the scan and emit artifacts/alerts."""
+    logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
+
     proj_path = os.environ.get("PROJECTIONS_PATH", "data/projections.csv")
     api_key = os.environ.get("ODDS_API_KEY", "")
     if not api_key:
-        print("Missing ODDS_API_KEY.")
+        logging.error("Missing ODDS_API_KEY.")
         return 2
 
     threshold = float(os.environ.get("EDGE_THRESHOLD", "0.06"))
     profile = os.environ.get("MARKETS_PROFILE", "base")
     df_proj = load_projections(proj_path)
 
-    cfg = default_config()
+    cfg = load_config()
     df_edges = scan_edges(
         df_proj,
         cfg,
         api_key=api_key,
         days_from=7,
         profile=profile,
-        max_calls=1000
+        max_calls=1000,
     )
 
     os.makedirs("artifacts", exist_ok=True)
@@ -134,10 +102,12 @@ def main() -> int:
     with open("artifacts/advice.txt", "w", encoding="utf-8") as f:
         f.write(adv + "\n")
 
-    print("\n=== ADVICE ===\n" + adv + "\n")
+    logging.info("\n=== ADVICE ===\n%s\n", adv)
 
     alert_edges(df_edges, threshold_ev=threshold)
     return 0
 
+
 if __name__ == "__main__":
     sys.exit(main())
+

--- a/agent_core.py
+++ b/agent_core.py
@@ -18,52 +18,73 @@ logging.basicConfig(
 
 # -------------------- Odds & probability helpers --------------------
 def american_to_implied_p(odds: int) -> float:
+    """Convert American odds to an implied win probability."""
     return (-odds)/((-odds)+100) if odds < 0 else 100/(odds+100)
 
 def normal_cdf(x: float, mu: float, sd: float) -> float:
+    """Return the CDF of ``N(mu, sd^2)`` at ``x``.
+
+    A zero or negative standard deviation yields a step function at ``mu``
+    instead of raising.
+    """
     if sd <= 0:
         return 1.0 if x >= mu else 0.0
     z = (x - mu) / sd
     return 0.5 * (1 + erf(z / sqrt(2)))
 
-def prob_over(line: float, mu: float, sd: float, is_discrete: bool=False) -> float:
+def prob_over(line: float, mu: float, sd: float, is_discrete: bool = False) -> float:
+    """Probability the outcome exceeds ``line`` given mean ``mu``/sd ``sd``."""
     return 1 - normal_cdf(line + (0.5 if is_discrete else 0.0), mu, sd)
 
 def ev_per_unit(p: float, american_odds: int) -> float:
+    """Expected profit per 1 unit wagered."""
     b = (100/abs(american_odds)) if american_odds < 0 else (american_odds/100)
-    return p*b - (1-p)*1
+    return p * b - (1 - p) * 1
 
 def kelly_fraction(p: float, american_odds: int) -> float:
+    """Fraction of bankroll to wager according to the Kelly criterion."""
     b = (100/abs(american_odds)) if american_odds < 0 else (american_odds/100)
-    if b <= 0: return 0.0
+    if b <= 0:
+        return 0.0
     q = 1 - p
-    return max(0.0, (b*p - q) / b)
+    return max(0.0, (b * p - q) / b)
 
 # -------------------- HTTP + usage logging --------------------
 def _requests_session() -> requests.Session:
+    """Return a ``requests.Session`` with our user agent set."""
     s = requests.Session()
     s.headers.update({"User-Agent": USER_AGENT})
     return s
 
-def _log_usage(resp: requests.Response, tag: str=""):
+def _log_usage(resp: requests.Response, tag: str = "") -> None:
+    """Persist Odds API usage headers for later inspection."""
     used = resp.headers.get("x-requests-used")
     remaining = resp.headers.get("x-requests-remaining")
     last_cost = resp.headers.get("x-requests-last")
-    logging.info(f"[ODDS-API]{' '+tag if tag else ''} used={used} remaining={remaining} last_call_cost={last_cost}")
+    logging.info(
+        f"[ODDS-API]{' '+tag if tag else ''} used={used} remaining={remaining} last_call_cost={last_cost}"
+    )
     row = {
         "ts_utc": dt.datetime.utcnow().isoformat(timespec="seconds"),
         "endpoint": resp.request.path_url,
         "tag": tag,
         "status": resp.status_code,
-        "used": used, "remaining": remaining, "last_cost": last_cost
+        "used": used,
+        "remaining": remaining,
+        "last_cost": last_cost,
     }
     write_header = not os.path.exists(CALL_LOG_PATH)
     with open(CALL_LOG_PATH, "a", newline="", encoding="utf-8") as f:
         w = csv.DictWriter(f, fieldnames=row.keys())
-        if write_header: w.writeheader()
+        if write_header:
+            w.writeheader()
         w.writerow(row)
 
-def http_get_json(session: requests.Session, url: str, params: Dict, tag: str="") -> dict:
+def http_get_json(session: requests.Session, url: str, params: Dict, tag: str = "") -> dict:
+    """GET ``url`` with ``params`` and return the parsed JSON.
+
+    Retries up to three times on 5xx responses.
+    """
     for attempt in range(3):
         resp = session.get(url, params=params, timeout=25)
         _log_usage(resp, tag=tag)
@@ -76,26 +97,39 @@ def http_get_json(session: requests.Session, url: str, params: Dict, tag: str=""
     return {}
 
 # -------------------- Odds API wrappers + budgeting --------------------
-def list_upcoming_events(api_key: str, sport_key: str = NFL_SPORT_KEY, days_from: int = 7) -> List[dict]:
+def list_upcoming_events(
+    api_key: str, sport_key: str = NFL_SPORT_KEY, days_from: int = 7
+) -> List[dict]:
+    """Return upcoming events from the Odds API."""
     session = _requests_session()
     url = f"https://api.the-odds-api.com/v4/sports/{sport_key}/events"
     params = {"apiKey": api_key, "daysFrom": days_from}
     return http_get_json(session, url, params, tag="events_free")
 
-def get_event_odds(api_key: str, event_id: str, regions: str, odds_format: str, markets: str) -> dict:
+def get_event_odds(
+    api_key: str, event_id: str, regions: str, odds_format: str, markets: str
+) -> dict:
+    """Fetch odds for ``event_id`` and return JSON data."""
     session = _requests_session()
     url = f"https://api.the-odds-api.com/v4/sports/{NFL_SPORT_KEY}/events/{event_id}/odds"
-    params = {"apiKey": api_key, "regions": regions, "oddsFormat": odds_format, "markets": markets}
+    params = {
+        "apiKey": api_key,
+        "regions": regions,
+        "oddsFormat": odds_format,
+        "markets": markets,
+    }
     tag = f"event={event_id} markets={markets}"
     return http_get_json(session, url, params, tag=tag)
 
-def estimate_credits(num_events: int, markets: List[str], regions: str="us") -> int:
+def estimate_credits(num_events: int, markets: List[str], regions: str = "us") -> int:
+    """Estimate Odds API credits consumed by a run."""
     n_markets = len(markets)
     n_regions = len(regions.split(",")) if isinstance(regions, str) else 1
     return num_events * n_markets * n_regions
 
 # -------------------- Name & market helpers --------------------
 def normalize_name(n: str) -> str:
+    """Lowercase and strip punctuation/whitespace from a name."""
     n = (n or "").lower().strip()
     n = re.sub(r"[.,'’]", "", n)
     n = re.sub(r"\s+", " ", n)
@@ -107,9 +141,11 @@ DISCRETE_KEYS = {
 }
 
 def is_discrete_market(market_key: str) -> bool:
+    """Whether ``market_key`` represents a discrete outcome."""
     return market_key in DISCRETE_KEYS
 
 def sanity_line_ok(market_key: str, line: float) -> bool:
+    """Quick sanity check that a book's line is non-negative."""
     if line is None:
         return False
     try:
@@ -118,22 +154,27 @@ def sanity_line_ok(market_key: str, line: float) -> bool:
         return False
 
 # -------------------- Variance blending --------------------
-def make_variance_blend(row: pd.Series, market_key: str, sigma_cfg: dict, alpha: float) -> float:
+def make_variance_blend(
+    row: pd.Series, market_key: str, sigma_cfg: dict, alpha: float
+) -> float:
+    """Blend player-specific and positional variance estimates."""
     pos = str(row.get("pos") or row.get("position") or "").upper()
     src_sd = None
     for cand in [f"{market_key}_sd", market_key.replace("player_", "") + "_sd"]:
         if cand in row and pd.notna(row[cand]):
             try:
-                src_sd = float(row[cand]); break
+                src_sd = float(row[cand])
+                break
             except Exception:
                 pass
     base_sigma = float(sigma_cfg.get(pos, {}).get(market_key, 25.0))
     if src_sd is None:
         return base_sigma
-    return math.sqrt(alpha * (src_sd ** 2) + (1 - alpha) * (base_sigma ** 2))
+    return math.sqrt(alpha * (src_sd**2) + (1 - alpha) * (base_sigma**2))
 
 # -------------------- Best offer (robust name + fallback books) --------------------
 def _player_name_match(desc: str, player_norm: str) -> bool:
+    """Heuristic match between Odds API description and projection name."""
     if not desc:
         return False
     dn = normalize_name(desc)
@@ -151,7 +192,10 @@ def _player_name_match(desc: str, player_norm: str) -> bool:
         return last_ok and first_ok
     return pt[0] in dt
 
-def best_offer_for_player(event_json: dict, player_name: str, market_key: str, side: str, target_books: set):
+def best_offer_for_player(
+    event_json: dict, player_name: str, market_key: str, side: str, target_books: set
+):
+    """Find the best line/price for a player and market."""
     player_norm = normalize_name(player_name)
 
     def _search(allowed_books: Optional[set]) -> Optional[Tuple[str, float, int]]:
@@ -174,11 +218,13 @@ def best_offer_for_player(event_json: dict, player_name: str, market_key: str, s
                     )
                     if not _player_name_match(pstr, player_norm):
                         continue
-                    line = outc.get("point"); price = outc.get("price")
+                    line = outc.get("point")
+                    price = outc.get("price")
                     if line is None or price is None:
                         continue
                     try:
-                        line = float(line); price = int(price)
+                        line = float(line)
+                        price = int(price)
                     except Exception:
                         continue
                     if not sanity_line_ok(market_key, line):
@@ -188,10 +234,14 @@ def best_offer_for_player(event_json: dict, player_name: str, market_key: str, s
                         best_local = cand
                     else:
                         if side == "OVER":
-                            if cand[1] < best_local[1] or (cand[1] == best_local[1] and cand[2] > best_local[2]):
+                            if cand[1] < best_local[1] or (
+                                cand[1] == best_local[1] and cand[2] > best_local[2]
+                            ):
                                 best_local = cand
                         else:
-                            if cand[1] > best_local[1] or (cand[1] == best_local[1] and cand[2] > best_local[2]):
+                            if cand[1] > best_local[1] or (
+                                cand[1] == best_local[1] and cand[2] > best_local[2]
+                            ):
                                 best_local = cand
         return best_local
 

--- a/alerts.py
+++ b/alerts.py
@@ -1,13 +1,19 @@
-# alerts.py
-import os, json
+"""Slack alert helpers for NFL Prop Agent."""
+
+import json
+import logging
+import os
 from typing import Optional
+
 import requests
 import pandas as pd
 
 def _fmt_pct(x: float) -> str:
+    """Format a probability/EV float as a percentage string."""
     return f"{x*100:.1f}%"
 
 def _market_readable(mkey: str) -> str:
+    """Return a human-friendly name for ``mkey``."""
     m = {
         "player_pass_yds": "passing yards",
         "player_rush_yds": "rushing yards",
@@ -25,6 +31,7 @@ def _market_readable(mkey: str) -> str:
     return m.get(mkey, mkey.replace("_", " "))
 
 def format_advice(df: pd.DataFrame, threshold: float) -> str:
+    """Create a multi-line Slack message summarizing high-EV edges."""
     if df is None or df.empty:
         return "No edges found."
     lines = []
@@ -37,25 +44,39 @@ def format_advice(df: pd.DataFrame, threshold: float) -> str:
         )
     return "\n".join(lines[:25]) if lines else "No edges ≥ threshold."
 
-def alert_edges(df: pd.DataFrame, threshold_ev: float = 0.06, webhook: Optional[str] = None) -> None:
+def alert_edges(
+    df: pd.DataFrame, threshold_ev: float = 0.06, webhook: Optional[str] = None
+) -> None:
+    """Post formatted edges to Slack or write a failure artifact."""
     os.makedirs("artifacts", exist_ok=True)
     webhook = webhook or os.environ.get("SLACK_WEBHOOK", "")
     msg = "*NFL Edges*\n" + format_advice(df, threshold_ev)
     if not webhook:
         with open("artifacts/slack_failed.txt", "w", encoding="utf-8") as f:
             f.write("No SLACK_WEBHOOK set\n" + msg)
-        print("[SLACK] Webhook not set; wrote artifacts/slack_failed.txt")
+        logging.warning("[SLACK] Webhook not set; wrote artifacts/slack_failed.txt")
         return
-    try:
-        resp = requests.post(webhook, data=json.dumps({"text": msg}),
-                             headers={"Content-Type": "application/json"}, timeout=12)
-        if resp.status_code >= 400:
-            with open("artifacts/slack_failed.txt", "w", encoding="utf-8") as f:
-                f.write(f"HTTP {resp.status_code}\n{resp.text}\n\n{msg}")
-            print(f"[SLACK] Error {resp.status_code}; wrote artifacts/slack_failed.txt")
-        else:
-            print("[SLACK] Posted advice.")
-    except Exception as e:
-        with open("artifacts/slack_failed.txt", "w", encoding="utf-8") as f:
-            f.write(f"Exception: {e}\n\n{msg}")
-        print(f"[SLACK] Exception; wrote artifacts/slack_failed.txt")
+
+    payload = json.dumps({"text": msg})
+    for attempt in range(3):
+        try:
+            resp = requests.post(
+                webhook,
+                data=payload,
+                headers={"Content-Type": "application/json"},
+                timeout=12,
+            )
+            if resp.status_code < 400:
+                logging.info("[SLACK] Posted advice.")
+                return
+            logging.error("[SLACK] HTTP %s", resp.status_code)
+        except Exception as e:  # pragma: no cover - network errors
+            logging.exception("[SLACK] Exception posting to webhook: %s", e)
+        if attempt < 2:
+            import time
+
+            time.sleep(2 * (attempt + 1))
+
+    with open("artifacts/slack_failed.txt", "w", encoding="utf-8") as f:
+        f.write(msg)
+    logging.error("[SLACK] Failed after retries; wrote artifacts/slack_failed.txt")

--- a/app.py
+++ b/app.py
@@ -1,55 +1,28 @@
-import os, io, pandas as pd, streamlit as st
+import os, pandas as pd, streamlit as st
 from agent_core import scan_edges
+from config import load_config
+
+CFG = load_config()
 
 st.set_page_config(page_title="NFL Prop Agent", layout="wide")
 
 st.sidebar.header("Settings")
-api_key = st.sidebar.text_input("Odds API Key", value=st.secrets.get("ODDS_API_KEY", ""), type="password")
+api_key = st.sidebar.text_input(
+    "Odds API Key", value=st.secrets.get("ODDS_API_KEY", ""), type="password"
+)
 days = st.sidebar.slider("Days ahead (events)", 1, 14, 7, 1)
-profile = st.sidebar.selectbox("Market profile", ["base","heavy"], index=0)
-max_calls = st.sidebar.number_input("Max estimated credits per run", min_value=50, value=2000, step=50)
+profile = st.sidebar.selectbox(
+    "Market profile", list(CFG.get("markets", {}).keys()), index=0
+)
+max_calls = st.sidebar.number_input(
+    "Max estimated credits per run", min_value=50, value=2000, step=50
+)
 run_btn = st.sidebar.button("Run scan", type="primary")
 
 st.title("NFL Prop Agent")
 st.caption("Upload projections, fetch best-book props, compute EV, and size stakes.")
 
 uploaded = st.file_uploader("Upload projections CSV", type=["csv"])
-
-# default config (matches CLI)
-CFG = {
-    "regions": "us",
-    "target_books": ["fanduel","espnbet","betmgm","caesars","fanatics","ballybet"],
-    "blend_alpha": 0.35,
-    "markets": {
-        "base": [
-            "player_pass_yds","player_rush_yds","player_reception_yds","player_receptions",
-            "player_pass_tds","player_rush_tds","player_reception_tds"
-        ],
-        "heavy": [
-            "player_pass_yds","player_rush_yds","player_reception_yds","player_receptions",
-            "player_pass_tds","player_rush_tds","player_reception_tds",
-            "player_pass_attempts","player_pass_completions","player_interceptions",
-            "player_longest_reception","player_longest_rush"
-        ]
-    },
-    "sigma_defaults": {
-        "QB": {"player_pass_yds": 60, "player_pass_tds": 0.75, "player_interceptions": 0.5,
-               "player_pass_attempts": 6, "player_pass_completions": 5},
-        "RB": {"player_rush_yds": 20, "player_rush_tds": 0.5, "player_receptions": 1.6,
-               "player_reception_yds": 18, "player_longest_rush": 7},
-        "WR": {"player_receptions": 2.0, "player_reception_yds": 30, "player_reception_tds": 0.5,
-               "player_longest_reception": 8},
-        "TE": {"player_receptions": 1.6, "player_reception_yds": 22, "player_reception_tds": 0.45,
-               "player_longest_reception": 7}
-    },
-    "bankroll": 1000.0,
-    "unit_pct": 0.01,
-    "stake_bands": [
-        {"min_ev": 0.08, "stake_u": 1.0},
-        {"min_ev": 0.04, "stake_u": 0.5},
-        {"min_ev": 0.02, "stake_u": 0.3}
-    ]
-}
 
 if uploaded is not None:
     df = pd.read_csv(uploaded)
@@ -61,8 +34,12 @@ if uploaded is not None:
             st.error("Please provide an Odds API key in the sidebar.")
         else:
             edges = scan_edges(
-                df, CFG, api_key=api_key,
-                days_from=days, profile=profile, max_calls=int(max_calls)
+                df,
+                CFG,
+                api_key=api_key,
+                days_from=days,
+                profile=profile,
+                max_calls=int(max_calls),
             )
             if edges.empty:
                 st.warning("No edges found (or no matching props at selected books).")
@@ -72,12 +49,22 @@ if uploaded is not None:
 
                 # download results
                 csv_bytes = edges.to_csv(index=False).encode("utf-8")
-                st.download_button("Download edges CSV", data=csv_bytes, file_name="edges_bestbook.csv", mime="text/csv")
+                st.download_button(
+                    "Download edges CSV",
+                    data=csv_bytes,
+                    file_name="edges_bestbook.csv",
+                    mime="text/csv",
+                )
 
                 # usage log (if present)
                 try:
-                    with open("odds_api_calls.csv","rb") as f:
-                        st.download_button("Download API call log (CSV)", data=f, file_name="odds_api_calls.csv", mime="text/csv")
+                    with open("odds_api_calls.csv", "rb") as f:
+                        st.download_button(
+                            "Download API call log (CSV)",
+                            data=f,
+                            file_name="odds_api_calls.csv",
+                            mime="text/csv",
+                        )
                 except FileNotFoundError:
                     st.info("Run produced no usage log file (unexpected).")
 

--- a/config.py
+++ b/config.py
@@ -1,0 +1,51 @@
+"""Configuration loader for the NFL prop agent.
+
+This module centralizes loading of configuration values from
+``agent_config.yaml`` so that both the CLI and the Streamlit app read the
+same settings.  The structure returned by :func:`load_config` matches what
+``scan_edges`` expects.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+import yaml
+
+
+def load_config(path: str = "agent_config.yaml") -> Dict[str, Any]:
+    """Load configuration from ``path``.
+
+    Parameters
+    ----------
+    path:
+        Location of the YAML config file.
+
+    Returns
+    -------
+    dict
+        Mapping suitable for ``scan_edges``.
+    """
+
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Config file not found at {path}")
+
+    with open(path, "r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f) or {}
+
+    # Adapt keys from YAML to the structure used throughout the codebase.
+    return {
+        "regions": raw.get("regions", "us"),
+        "target_books": raw.get("target_books", []),
+        # Treat the top-level "markets" list as the default profile.
+        "markets": {"base": raw.get("markets", [])},
+        # YAML may use either outcome_sigma or sigma_defaults naming.
+        "sigma_defaults": raw.get("outcome_sigma", raw.get("sigma_defaults", {})),
+        "blend_alpha": raw.get("blend_alpha", 0.35),
+        "bankroll": raw.get("bankroll", 1000.0),
+        "unit_pct": raw.get("unit_pct", 0.01),
+        # Staking bands appear as "ev_bands" or "stake_bands".
+        "stake_bands": raw.get("ev_bands", raw.get("stake_bands", [])),
+    }
+

--- a/firestore_push.py
+++ b/firestore_push.py
@@ -1,24 +1,43 @@
-import argparse, csv, os, json
+"""Utility to push CSV rows into a Google Firestore collection."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+
 from google.cloud import firestore
 
-def push_csv(path: str, collection: str):
+
+def push_csv(path: str, collection: str) -> None:
+    """Stream rows from ``path`` into ``collection`` using batched writes."""
     db = firestore.Client()
     batch = db.batch()
-    with open(path, newline="", encoding="utf-8") as f:
-        r = csv.DictReader(f)
-        for i, row in enumerate(r):
-            doc_ref = db.collection(collection).document()
-            batch.set(doc_ref, row)
-            if (i+1) % 400 == 0:
-                batch.commit(); batch = db.batch()
-        batch.commit()
-    print(f"Pushed {i+1} rows to {collection}")
+    pushed = 0
+    try:
+        with open(path, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            for i, row in enumerate(reader, start=1):
+                doc_ref = db.collection(collection).document()
+                batch.set(doc_ref, row)
+                pushed = i
+                if i % 400 == 0:
+                    batch.commit()
+                    batch = db.batch()
+            batch.commit()
+        logging.info("Pushed %d rows to %s", pushed, collection)
+    except Exception as e:  # pragma: no cover - Firestore/network errors
+        logging.exception("Failed to push CSV to Firestore: %s", e)
+        raise
+
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     ap = argparse.ArgumentParser()
     ap.add_argument("--csv", required=True)
-    ap.add_argument("--collection", required=True, help='e.g. "nfl_props/2025_wk1/edges"')
+    ap.add_argument(
+        "--collection", required=True, help='e.g. "nfl_props/2025_wk1/edges"'
+    )
     args = ap.parse_args()
 
-    # Requires GOOGLE_APPLICATION_CREDENTIALS env var to a service-account JSON
     push_csv(args.csv, args.collection)


### PR DESCRIPTION
## Summary
- add `config.load_config` to share settings across CLI and Streamlit app
- switch CLI and alerts to structured logging with retries for Slack posts
- harden Firestore CSV importer and document core engine helpers

## Testing
- `python -m py_compile app.py alerts.py firestore_push.py agent_cli.py agent_core.py config.py`
- `R -q -e "parse('R/fetch_projections.R'); parse('scripts/ffa_fetch.R'); parse('scripts/ffa_shiny_download.R')"` *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c34590648326818d79fd47f72ea9