### PR TITLE
Adjust player name fallbacks before description

### DIFF
--- a/agent_core.py
+++ b/agent_core.py
@@ -274,14 +274,16 @@ def best_offer_for_player(
                 if mk.get("key") != market_key:
                     continue
                 for outc in mk.get("outcomes", []) or []:
-                    pstr = (
-                        outc.get("description")
-                        or outc.get("participant")
-                        or outc.get("player")
-                        or outc.get("player_name")
-                        or outc.get("name")
-                        or ""
+                    pstr = next(
+                        (
+                            outc.get(field)
+                            for field in ("participant", "player", "player_name", "name")
+                            if outc.get(field)
+                        ),
+                        None,
                     )
+                    if not pstr:
+                        pstr = outc.get("description") or ""
                     if not _player_name_match(pstr, player_norm):
                         continue
                     line = outc.get("point")


### PR DESCRIPTION
## Summary
- prefer participant and player-specific fields over description when matching Odds API outcomes to projection names

## Testing
- python -m compileall agent_core.py

------
https://chatgpt.com/codex/tasks/task_e_68cad7629ae88326822d2331d9ab1736