### PR TITLE
Handle missing projection values

### DIFF
--- a/agent_core.py
+++ b/agent_core.py
@@ -466,6 +466,9 @@ def scan_edges(
                 except Exception:
                     bump(f"bad_projection_value::{mkey}")
                     continue
+                if pd.isna(r[mkey]):
+                    bump(f"missing_projection_value::{mkey}")
+                    continue
                 sd = make_variance_blend(r, mkey, sigma_defaults, alpha)
                 for side in ("OVER", "UNDER"):
                     offer = best_offer_for_player(ev_json, player, mkey, side, target_books)
@@ -539,5 +542,14 @@ def scan_edges(
         f.write("reasons:\n")
         for k, v in sorted(diag["reasons"].items(), key=lambda kv: (-kv[1], kv[0])):
             f.write(f"  {k}: {v}\n")
+        missing_proj = {
+            reason.partition("::")[2]: count
+            for reason, count in diag["reasons"].items()
+            if reason.startswith("missing_projection_value::")
+        }
+        if missing_proj:
+            f.write("missing_projection_values:\n")
+            for market, count in sorted(missing_proj.items(), key=lambda kv: (-kv[1], kv[0])):
+                f.write(f"  {market}: {count}\n")
 
     return df


### PR DESCRIPTION
## Summary
- treat NaN projection values as missing before calculating edges
- bump a missing_projection_value::<market> diagnostic and skip odds requests when a projection is NaN
- surface a dedicated missing projection section in scan_summary.txt for easier debugging

## Testing
- python -m compileall agent_core.py

------
https://chatgpt.com/codex/tasks/task_e_68cad9320ebc8326a5c033a4d25d7cff