### PR TITLE
Expose diagnostics and fallback offers

### DIFF
--- a/alerts.py
+++ b/alerts.py
@@ -45,9 +45,19 @@ def format_advice(df: pd.DataFrame, threshold: float) -> str:
     for _, r in df.iterrows():
         if r["ev_per_unit"] < threshold:
             continue
+        fallback_note = ""
+        fb_book = r.get("fallback_book")
+        if fb_book and isinstance(fb_book, str):
+            fb_line = r.get("fallback_line")
+            fb_odds = r.get("fallback_odds")
+            line_str = "NA"
+            if not pd.isna(fb_line):
+                line_str = f"{fb_line:g}" if isinstance(fb_line, (int, float)) else str(fb_line)
+            odds_str = "NA" if pd.isna(fb_odds) else str(int(fb_odds))
+            fallback_note = f" (alt: {fb_book} {odds_str} @ {line_str})"
         lines.append(
             f"{r['player']} {r['side']} {r['book_line']} {_market_readable(r['market_key'])} — "
-            f"{r['book_odds']} ({r['best_book']}) | EV {_fmt_pct(r['ev_per_unit'])} | {r['stake_u']}u"
+            f"{r['book_odds']} ({r['best_book']}) | EV {_fmt_pct(r['ev_per_unit'])} | {r['stake_u']}u{fallback_note}"
         )
     return "\n".join(lines[:25]) if lines else "No edges ≥ threshold."
 


### PR DESCRIPTION
## Summary
- extend the edge scanner to capture fallback offers, bookmaker coverage, and missing-event diagnostics while returning the metadata with each scan
- surface the diagnostic summary in the CLI, write dedicated artifacts, and include fallback context in CLI and Slack advice messaging
- validate configured target_books against a known bookmaker catalog and report projection coverage for requested markets

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cc4e5275988326af2360c062165664