### PR TITLE
Surface diagnostics when scans find no edges

### DIFF
--- a/agent_cli.py
+++ b/agent_cli.py
@@ -17,8 +17,9 @@ import pandas as pd
 
 from agent_core import scan_edges
 from alerts import alert_edges
-from config import load_config
+from config import load_config, validate_target_books
 from cleaning import clean_projections
+from diagnostics import format_scan_diagnostics, format_no_edge_summary
 from file_finder import resolve_projection_path  # NEW
 
 def load_projections(path: str) -> pd.DataFrame:
@@ -33,10 +34,57 @@ def load_projections(path: str) -> pd.DataFrame:
     )
     return df
 
+def projection_health_summary(df: pd.DataFrame, markets: list[str]) -> list[dict]:
+    """Return coverage stats for requested markets."""
+    total = int(len(df))
+    summary: list[dict] = []
+    if not markets:
+        return summary
+    for market in markets:
+        entry = {"market": market, "total": total}
+        if market not in df.columns:
+            entry["status"] = "missing_column"
+        else:
+            missing = int(df[market].isna().sum())
+            entry.update({
+                "status": "ok",
+                "missing": missing,
+                "available": total - missing,
+            })
+        summary.append(entry)
+    return summary
+
+
+def format_projection_health(summary: list[dict]) -> list[str]:
+    """Format projection health stats for logging/artifacts."""
+    lines: list[str] = []
+    for entry in summary:
+        market = entry.get("market")
+        total = entry.get("total", 0)
+        status = entry.get("status")
+        if status == "missing_column":
+            lines.append(f"{market}: column missing ({total} players affected)")
+        else:
+            available = entry.get("available", 0)
+            missing = entry.get("missing", 0)
+            pct = (available / total * 100) if total else 0.0
+            lines.append(
+                f"{market}: {available}/{total} projections ({pct:.1f}% coverage, missing {missing})"
+            )
+    return lines
+
+
 def advice_lines(df: pd.DataFrame, threshold: float) -> str:
     """Format human-readable advice lines for Slack/console."""
-    if df is None or df.empty:
-        return "No edges found."
+    diag: dict = {}
+    if isinstance(df, pd.DataFrame):
+        diag = df.attrs.get("diagnostics", {}) or {}
+    if df is None or not isinstance(df, pd.DataFrame):
+        summary = format_no_edge_summary(diag, reason_limit=5, heading="Diagnostics:")
+        return "No edges found." if not summary else "No edges found.\n" + summary
+    if df.empty:
+        summary = format_no_edge_summary(diag, reason_limit=5, heading="Diagnostics:")
+        return "No edges found." if not summary else "No edges found.\n" + summary
     name_map = {
         "player_pass_yds": "passing yards",
         "player_rush_yds": "rushing yards",
@@ -62,13 +110,23 @@ def advice_lines(df: pd.DataFrame, threshold: float) -> str:
     }
     keep = df[df["ev_per_unit"] >= threshold].copy()
     if keep.empty:
-        return "No edges ≥ threshold."
+        summary = format_no_edge_summary(diag, reason_limit=5, heading="Diagnostics:")
+        return "No edges ≥ threshold." if not summary else "No edges ≥ threshold.\n" + summary
     lines = []
     for _, r in keep.head(50).iterrows():
         evp = f"{r['ev_per_unit']*100:.1f}%"
+        fallback_note = ""
+        fb_book = r.get("fallback_book")
+        if fb_book and isinstance(fb_book, str):
+            fb_line = r.get("fallback_line")
+            fb_odds = r.get("fallback_odds")
+            if pd.notna(fb_book):
+                line_str = "NA" if pd.isna(fb_line) else f"{fb_line:g}" if isinstance(fb_line, (int, float)) else str(fb_line)
+                odds_str = "NA" if pd.isna(fb_odds) else str(int(fb_odds))
+                fallback_note = f" (alt: {fb_book} {odds_str} @ {line_str})"
         lines.append(
             f"{r['player']} {r['side']} {r['book_line']} {name_map.get(r['market_key'], r['market_key'])} — "
-            f"{r['book_odds']} ({r['best_book']}) | EV {evp} | {r['stake_u']}u"
+            f"{r['book_odds']} ({r['best_book']}) | EV {evp} | {r['stake_u']}u{fallback_note}"
         )
     return "\n".join(lines)
 
@@ -95,8 +153,42 @@ def main() -> int:
     threshold = float(os.environ.get("EDGE_THRESHOLD", "0.06"))
     profile = os.environ.get("MARKETS_PROFILE", "base")
 
-    df_proj = load_projections(proj_path)
     cfg = load_config()
+    markets_for_profile = cfg.get("markets", {}).get(profile, cfg.get("markets", {}).get("base", []))
+    if markets_for_profile:
+        logging.info("Markets for profile '%s': %s", profile, markets_for_profile)
+    else:
+        logging.warning("No markets configured for profile '%s'.", profile)
+
+    book_check = validate_target_books(cfg.get("target_books", []))
+    if book_check["unknown"]:
+        logging.warning("Unknown target_books keys: %s", ", ".join(book_check["unknown"]))
+        for book, suggestions in book_check["suggestions"].items():
+            logging.warning("  %s → possible matches: %s", book, ", ".join(suggestions))
+    elif not cfg.get("target_books"):
+        logging.info("No target_books configured; scan will consider all bookmakers.")
+
+    df_proj = load_projections(proj_path)
+    proj_summary = projection_health_summary(df_proj, list(markets_for_profile or []))
+    for entry in proj_summary:
+        status = entry.get("status")
+        market = entry.get("market")
+        if status == "missing_column":
+            logging.warning("Projection column missing for %s (profile=%s)", market, profile)
+        else:
+            missing = entry.get("missing", 0)
+            if missing > 0:
+                available = entry.get("available", 0)
+                total = entry.get("total", 0)
+                pct = (available / total * 100) if total else 0.0
+                logging.info(
+                    "Projection coverage for %s: %d/%d (%.1f%%); missing=%d",
+                    market,
+                    available,
+                    total,
+                    pct,
+                    missing,
+                )
 
     # Determine how far ahead to look for events.  Default to 2 days, but allow
     # override via the DAYS_FROM environment variable.  In practice, player
@@ -117,9 +209,26 @@ def main() -> int:
         max_calls=1000,
     )
 
+    diag = {}
+    if isinstance(df_edges, pd.DataFrame):
+        diag = df_edges.attrs.get("diagnostics", {})
+    diag_lines = format_scan_diagnostics(diag)
+    proj_lines = format_projection_health(proj_summary)
+    if diag_lines:
+        logging.info("\n=== SCAN DIAGNOSTICS ===\n%s\n", "\n".join(diag_lines))
+    if any(entry.get("status") == "missing_column" or entry.get("missing", 0) > 0 for entry in proj_summary):
+        logging.info("Projection coverage summary:\n%s", "\n".join(proj_lines))
+
     os.makedirs("artifacts", exist_ok=True)
     if df_edges is not None and not df_edges.empty:
         df_edges.to_csv("artifacts/edges.csv", index=False)
+
+    if proj_lines:
+        with open("artifacts/projection_health.txt", "w", encoding="utf-8") as f:
+            f.write("\n".join(proj_lines) + "\n")
+    if diag_lines:
+        with open("artifacts/diagnostics.txt", "w", encoding="utf-8") as f:
+            f.write("\n".join(diag_lines) + "\n")
 
     adv = advice_lines(df_edges, threshold)
     with open("artifacts/advice.txt", "w", encoding="utf-8") as f:

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -1,0 +1,91 @@
+"""Helpers for formatting scan diagnostics and summaries."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+
+def format_scan_diagnostics(diag: Optional[Dict], reason_limit: int = 10) -> List[str]:
+    """Return formatted diagnostic lines from a scan result."""
+
+    if not diag:
+        return []
+
+    lines: List[str] = []
+
+    events = diag.get("events")
+    events_used = diag.get("events_used")
+    if events is not None and events_used is not None:
+        lines.append(f"Events processed: {events_used}/{events}")
+
+    est = diag.get("estimated_credits")
+    if est is not None:
+        lines.append(f"Estimated credits: {est}")
+
+    markets_trimmed = diag.get("markets_trimmed")
+    if markets_trimmed:
+        lines.append("Markets trimmed for budget: " + ", ".join(markets_trimmed))
+
+    markets_effective = diag.get("markets_effective")
+    if markets_effective:
+        lines.append("Markets used: " + ", ".join(markets_effective))
+
+    target_books = diag.get("target_books")
+    if target_books:
+        lines.append("Target books: " + ", ".join(target_books))
+
+    seen = diag.get("bookmakers_encountered") or []
+    if seen:
+        lines.append("Bookmakers encountered: " + ", ".join(seen))
+
+    offers_by_book = diag.get("offers_by_book") or {}
+    if offers_by_book:
+        parts = [
+            f"{book}={count}"
+            for book, count in sorted(offers_by_book.items(), key=lambda kv: (-kv[1], kv[0]))
+        ]
+        lines.append("Offers by target book: " + ", ".join(parts))
+
+    fallback_counts = diag.get("fallback_counts") or {}
+    if fallback_counts:
+        parts = [
+            f"{book}={count}"
+            for book, count in sorted(fallback_counts.items(), key=lambda kv: (-kv[1], kv[0]))
+        ]
+        lines.append("Fallback outside target books: " + ", ".join(parts))
+
+    missing_events = diag.get("events_missing_bookmakers") or []
+    if missing_events:
+        sample = ", ".join(str(ev.get("event_id")) for ev in missing_events[:5])
+        lines.append(f"Events missing bookmakers: {len(missing_events)} (sample {sample})")
+
+    reasons = diag.get("reasons") or {}
+    if reasons:
+        lines.append("Top skip reasons:")
+        for reason, count in sorted(reasons.items(), key=lambda kv: (-kv[1], kv[0]))[:reason_limit]:
+            lines.append(f"  {reason}: {count}")
+
+    missing_proj = diag.get("missing_projection_values") or {}
+    if missing_proj:
+        lines.append("Missing projection counts:")
+        for market, count in sorted(missing_proj.items(), key=lambda kv: (-kv[1], kv[0])):
+            lines.append(f"  {market}: {count}")
+
+    return lines
+
+
+def format_no_edge_summary(
+    diag: Optional[Dict], *, reason_limit: int = 5, heading: Optional[str] = "Diagnostics:"
+) -> str:
+    """Return a short multi-line summary explaining why no edges surfaced."""
+
+    diag_lines = format_scan_diagnostics(diag, reason_limit=reason_limit)
+    if not diag_lines:
+        return ""
+
+    lines: List[str] = []
+    if heading:
+        lines.append(str(heading))
+    lines.extend(diag_lines)
+    return "\n".join(lines)
+


### PR DESCRIPTION
## Summary
- add a shared diagnostics helper so callers can reuse the same summary formatting
- update the CLI and Slack formatting to append skip-reason diagnostics whenever a scan returns no edges or misses the EV threshold
- surface the diagnostics inside the Streamlit app, both in the warning banner and in a collapsible panel for quick inspection

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cc4e5275988326af2360c062165664